### PR TITLE
Fastercormatrix

### DIFF
--- a/R/corMatrix.R
+++ b/R/corMatrix.R
@@ -2,11 +2,11 @@
 #'
 #' Creates a dataframe with imputed values using either linear regression or lasso based models. For each variable in given data frame, the function finds the best correlated predictors (number of which is set by top_predictors), and uses these to construct models for predicting missing values. 
 #'
-#' @param dataframe (Required) An input dataframe you would like a correlation matrix for. 
-#' @param continuous (Optional) A character vector containing variable names that should be treated as continuous. 
-#' @param categorical (Optional) A character vector containing variable names that should be treated as categorical. 
-#' @param varpattern A regular expression for subsetting variable names from input dataframe. 
-#' @param parallel (deprecated) 
+#' @param dataframe (Required) An input dataframe you would like a correlation matrix for.
+#' @param continuous (Optional) A character vector containing variable names that should be treated as continuous.
+#' @param categorical (Optional) A character vector containing variable names that should be treated as categorical.
+#' @param varpattern A regular expression for subsetting variable names from input dataframe.
+#' @param parallel (deprecated)
 #' @param test (deprecated)
 #' @param debug Debug mode; shows which models are running, the quality of predictions relative to original data, and any model errors. 1=progress notifications, errors and warnings.
 #'

--- a/R/imputation_regression.R
+++ b/R/imputation_regression.R
@@ -13,11 +13,9 @@
 #' @return Dataframe containing imputed variables, with imputations performed only on missing values and retaining original data where available.
 #'
 #' @examples
-#' \dontrun{regImputation(dataframe, method='polywog', varpattern="^c[mfhpktfvino]{1,2}[12345]", parallel=1, debug=1, test=1)}
+#' \dontrun{regImputation(dataframe, matrix, method='polywog', parallel=1, debug=1, test=1)}
 #'
 #' @export
-
-# Todo: better case logic instead of multiple if statements. 
 
 
 ## Main imputation script
@@ -105,7 +103,7 @@ regImputation <- function(dataframe, matrix, method='lm', parallel=0, threshold=
 						}
 
 						prediction <- stats::predict(model_fit, imputed_df , type='response')
-						prediction_unscaled <- prediction * sd(original_df[,col], na.rm=TRUE) + mean(original_df[,col], na.rm=TRUE)
+						prediction_unscaled <- prediction * stats::sd(original_df[,col], na.rm=TRUE) + mean(original_df[,col], na.rm=TRUE)
 						#print(head(prediction_unscaled, 20))
 						imputed <- ifelse(is.na(original_df[,col]), prediction_unscaled, original_df[,col])
 
@@ -140,7 +138,7 @@ regImputation <- function(dataframe, matrix, method='lm', parallel=0, threshold=
 						#print(summary(model_fit))	
 						#new[,column] <- data.frame(rep(0, nrow(imputed_df)))
 						prediction <- stats::predict(lm_fit, imputed_df, type='response')
-						prediction_unscaled <- prediction * sd(original_df[,col], na.rm=TRUE) + mean(original_df[,col], na.rm=TRUE)
+						prediction_unscaled <- prediction * stats::sd(original_df[,col], na.rm=TRUE) + mean(original_df[,col], na.rm=TRUE)
 						imputed <- ifelse(is.na(original_df[,col]), prediction_unscaled, original_df[,col])
 
 						if(debug>1) { 

--- a/R/imputation_regression.R
+++ b/R/imputation_regression.R
@@ -22,7 +22,7 @@
 
 ## Main imputation script
 
-regImputation <- function(dataframe, matrix, method='lm', parallel=0, threshold=0.4,top_predictors=3, debug=0, test=0, degree=1) {
+regImputation <- function(dataframe, matrix, method='lm', parallel=0, threshold=0.4,top_predictors=3, debug=0, degree=1, test=1) {
 
 	#avoid loading everything under the sun if we don't need it
 	if (method == 'polywog' | method=='lasso') {
@@ -50,23 +50,21 @@ regImputation <- function(dataframe, matrix, method='lm', parallel=0, threshold=
 	#make sure input is a data frame
 	if ("data.frame" %in% class(dataframe) & 'matrix' %in% class(matrix)) {
 
+		result = tryCatch({
+			if(debug>=1){message('Subsetting dataframe to match correlation matrix...')}
+			reduced_df <- dplyr::select(dataframe, dplyr::one_of(colnames(matrix)))
+		}, error = function(e) {
+			stop("Failed to match correlation matrix variables to input data frame.\nCheck that input data frame has (at least) all the columns specified in the input matrix.\nYou can give this function a dataframe with more variables than specified in the correlation matrix, but not less.")
+		})
 
-		if(debug>=1){message('Converting dataframe to numeric...')}
-		out_numeric <- data.frame(sapply(dataframe, as.numeric)) #converts to numeric
-		if(debug>=1){message('Imputing means...')}
+
+		if(debug>=1){message('Preparing dataframe for computation [1]...')}
+		out_numeric <- data.frame(suppressWarnings(sapply(reduced_df, as.numeric))) #converts to numeric
+		if(debug>=1){message('Preparing dataframe for computation [2]...')}
 		out_imputed <- zoo::na.aggregate(out_numeric)	#same shape as dataframe, but with means imputed
-		if(debug>=1){message('Scaling...')}	
+		if(debug>=1){message('Preparing dataframe for computation [3]...')}
 		out_scaled <- data.frame(lapply(out_imputed, function(x) scale(x)))
 		#print(head(out_scaled,20))
-
-
-		if(test == 1) {
-			message('Running in test mode')
-			columnstorun <- subset(out_scaled, select=c('cm4hhinc', 'cf4hhinc', 'cm5adult', 'cm1bsex'))
-			#columnstorun <- original_df[,1:4]
-		} else {
-			columnstorun <- out_scaled
-		}
 
 		impute <- function(column, cors, imputed_df, original_df) {
 			if(debug>=1){message(paste('Running variable', column))}
@@ -175,17 +173,21 @@ regImputation <- function(dataframe, matrix, method='lm', parallel=0, threshold=
 
 		} # end of impute function
 
-
+		if(test==1) {
+			colstorun <- subset(out_scaled, select=c('cm4hhinc', 'cf4hhinc', 'cm1kids', 'cf3adult'))
+		} else {
+			colstorun <- out_scaled
+		}
 		#if parallelization option is set 
 		if (parallel == 1) {
-				final <- parallel::mclapply(colnames(columnstorun), function(x) impute(x, matrix, out_scaled, dataframe), mc.cores=parallel::detectCores(logical=FALSE))
+				final <- parallel::mclapply(colnames(colstorun), function(x) impute(x, matrix, out_scaled, out_numeric), mc.cores=parallel::detectCores(logical=FALSE))
 				if(debug>=1) { message("Assembling predictions...") } 
 				final <- data.frame(do.call(cbind, final))
-				colnames(final) <- colnames(columnstorun)
+				colnames(final) <- colnames(colstorun)
 				return(final)
 		#run in sequence = off
 		} else {
-				final <- sapply(colnames(columnstorun), function(x) impute(x, matrix, out_scaled, dataframe))
+				final <- sapply(colnames(colstorun), function(x) impute(x, matrix, out_scaled, out_numeric))
 				final <- data.frame(final)
 				return(final)
 		}

--- a/man/corMatrix.Rd
+++ b/man/corMatrix.Rd
@@ -4,19 +4,26 @@
 \alias{corMatrix}
 \title{Correlation matrix to be used for regression based imputatoin}
 \usage{
-corMatrix(dataframe, varpattern = "", debug = 0, test = 1, parallel = 0)
+corMatrix(dataframe = "", continuous = "", categorical = "",
+  varpattern = "", debug = 0, test = 0, parallel = 0)
 }
 \arguments{
-\item{varpattern}{A regular expression for subsetting variable names from input dataframe}
+\item{dataframe}{(Required) An input dataframe you would like a correlation matrix for.}
 
-\item{debug}{debug mode; shows which models are running, the quality of predictions relative to original data, and any model errors. 1=progress notifications, errors and warnings.}
+\item{continuous}{(Optional) A character vector containing variable names that should be treated as continuous.}
+
+\item{categorical}{(Optional) A character vector containing variable names that should be treated as categorical.}
+
+\item{varpattern}{A regular expression for subsetting variable names from input dataframe.}
+
+\item{debug}{Debug mode; shows which models are running, the quality of predictions relative to original data, and any model errors. 1=progress notifications, errors and warnings.}
 
 \item{test}{(deprecated)}
 
 \item{parallel}{(deprecated)}
 }
 \value{
-a list of two objects: $corMatrix == the correlation matrix between all variables given in the input dataframe, $df ==  a filtered version of the dataframe, that removes columns with no variance and applies any regex filters given.
+A correlation matrix between all variables given in the input dataframe after removing columns with no variance and applying any regex filters given.
 }
 \description{
 Creates a dataframe with imputed values using either linear regression or lasso based models. For each variable in given data frame, the function finds the best correlated predictors (number of which is set by top_predictors), and uses these to construct models for predicting missing values.

--- a/man/corMatrix.Rd
+++ b/man/corMatrix.Rd
@@ -4,16 +4,16 @@
 \alias{corMatrix}
 \title{Correlation matrix to be used for regression based imputatoin}
 \usage{
-corMatrix(dataframe, varpattern = "", debug = 0)
+corMatrix(dataframe, varpattern = "", debug = 0, test = 1, parallel = 0)
 }
 \arguments{
 \item{varpattern}{A regular expression for subsetting variable names from input dataframe}
 
 \item{debug}{debug mode; shows which models are running, the quality of predictions relative to original data, and any model errors. 1=progress notifications, errors and warnings.}
 
-\item{parallel}{whether to use parallel processes (MacOS only, cores autodetected)}
+\item{test}{(deprecated)}
 
-\item{test}{test mode; runs on only the first 4 variables of a given dataframe; helpful for trying out the function options before running full correlation matrix.}
+\item{parallel}{(deprecated)}
 }
 \value{
 a list of two objects: $corMatrix == the correlation matrix between all variables given in the input dataframe, $df ==  a filtered version of the dataframe, that removes columns with no variance and applies any regex filters given.
@@ -22,6 +22,6 @@ a list of two objects: $corMatrix == the correlation matrix between all variable
 Creates a dataframe with imputed values using either linear regression or lasso based models. For each variable in given data frame, the function finds the best correlated predictors (number of which is set by top_predictors), and uses these to construct models for predicting missing values.
 }
 \examples{
-\dontrun{corMatrix(dataframe, varpattern="^c[mfhpktfvino]{1,2}[12345]", parallel=1, debug=1, test=1)}
+\dontrun{corMatrix(dataframe, varpattern="^c[mfhpktfvino]{1,2}[12345]", debug=1)}
 
 }

--- a/man/corMatrix.Rd
+++ b/man/corMatrix.Rd
@@ -4,16 +4,16 @@
 \alias{corMatrix}
 \title{Correlation matrix to be used for regression based imputatoin}
 \usage{
-corMatrix(dataframe, varpattern = "", debug = 0, test = 0, parallel = 0)
+corMatrix(dataframe, varpattern = "", debug = 0)
 }
 \arguments{
 \item{varpattern}{A regular expression for subsetting variable names from input dataframe}
 
 \item{debug}{debug mode; shows which models are running, the quality of predictions relative to original data, and any model errors. 1=progress notifications, errors and warnings.}
 
-\item{test}{test mode; runs on only the first 4 variables of a given dataframe; helpful for trying out the function options before running full correlation matrix.}
-
 \item{parallel}{whether to use parallel processes (MacOS only, cores autodetected)}
+
+\item{test}{test mode; runs on only the first 4 variables of a given dataframe; helpful for trying out the function options before running full correlation matrix.}
 }
 \value{
 a list of two objects: $corMatrix == the correlation matrix between all variables given in the input dataframe, $df ==  a filtered version of the dataframe, that removes columns with no variance and applies any regex filters given.

--- a/man/regImputation.Rd
+++ b/man/regImputation.Rd
@@ -30,6 +30,6 @@ Dataframe containing imputed variables, with imputations performed only on missi
 Creates a dataframe with imputed values using either linear regression or lasso based models. For each variable in given data frame, the function finds the best correlated predictors (number of which is set by top_predictors), and uses these to construct models for predicting missing values.
 }
 \examples{
-\dontrun{regImputation(dataframe, method='polywog', varpattern="^c[mfhpktfvino]{1,2}[12345]", parallel=1, debug=1, test=1)}
+\dontrun{regImputation(dataframe, matrix, method='polywog', parallel=1, debug=1, test=1)}
 
 }

--- a/man/regImputation.Rd
+++ b/man/regImputation.Rd
@@ -5,8 +5,8 @@
 \title{Linear regression and lasso based imputation}
 \usage{
 regImputation(dataframe, matrix, method = "lm", parallel = 0,
-  threshold = 0.4, top_predictors = 3, debug = 0, test = 0,
-  degree = 1)
+  threshold = 0.4, top_predictors = 3, debug = 0, degree = 1,
+  test = 1)
 }
 \arguments{
 \item{method}{method for imputation (\code{"lm"} for ordinary least squares linear regression or \code{"lasso"} for lasso regularization)}
@@ -19,9 +19,9 @@ regImputation(dataframe, matrix, method = "lm", parallel = 0,
 
 \item{debug}{debug mode; shows which models are running, the quality of predictions relative to original data, and any model errors. 1=progress, errors and warnings, 2=progress,errors, warnings and prediction quality.}
 
-\item{test}{test mode; runs on only the first 4 variables; helpful for trying out the function options before running full imputation.}
-
 \item{degree}{the degree of polynomial effects to estimate (1=main effects only, 2=quadratic, 3=cubic, etc.)}
+
+\item{test}{test mode; runs on only the first 4 variables; helpful for trying out the function options before running full imputation.}
 }
 \value{
 Dataframe containing imputed variables, with imputations performed only on missing values and retaining original data where available.


### PR DESCRIPTION
This implements a different, vectorized, solution for computing the corMatrix. Run time improves from about an hour (on 4 cores of a new Macbook Pro) to seconds. This also begins the implementation of support for distinguishing between categorical and continuous variables when making predictions (for now, this is not yet documented on the GitHub page, until regImputation is also updated). 

